### PR TITLE
adding overlaying ws

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,16 +13,17 @@ COPY solution.py ./
 COPY rosagent.py ./
 COPY lf_slim.launch ./
 
-# Uncomment these to build your own catkin_ws
+## Uncomment these to build your own catkin_ws
 #### START CUSTOM CATKIN_WS ####
+
 # RUN /bin/bash -c "mkdir -p catkin_ws/src/"
 
-# Copy or init your packages in here
-# COPY dt_dependent_node catkin_ws/src/dt_dependent_node
-# RUN chmod +x catkin_ws/src/dt_dependent_node/src/dt_dependent_node.py
+## Copy or init your packages in here
+# COPY dt_dependent_node catkin_ws/dt_dependent_node
+# RUN chmod +x catkin_ws/src/dt_dependent_node/dt_dependent_node.py
 
-# Do not change the below line! This ensures that your workspace is overlayed on top of the Duckietown stack!  
-# MAKE sure this line is present in the build: This workspace overlays: /home/software/catkin_ws/devel;/opt/ros/kinetic
+## Do not change the below line! This ensures that your workspace is overlayed on top of the Duckietown stack!  
+## MAKE sure this line is present in the build: This workspace overlays: /home/software/catkin_ws/devel;/opt/ros/kinetic
 # RUN /bin/bash -c "source /home/software/catkin_ws/devel/setup.bash && catkin_init_workspace && cd ../.."
 # RUN /bin/bash -c "source /home/software/catkin_ws/devel/setup.bash && catkin_make -j -C catkin_ws/"
 # RUN /bin/bash -c "source catkin_ws/devel/setup.bash"

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,22 @@ COPY solution.py ./
 # For ROS Agent - Additional Files
 COPY rosagent.py ./
 COPY lf_slim.launch ./
-COPY catkin_ws ./catkin_ws/
 
-# Uncomment these to build your own **SELF-CONTAINED** catkin_ws - warning: not the fastest!
-# RUN /bin/bash -c "source /opt/ros/kinetic/setup.bash && catkin_make -j -C catkin_ws/"
-# And adding it to the path
-# RUN echo "source $(pwd)/catkin_ws/devel/setup.bash" >> ~/.bashrc
+# Uncomment these to build your own catkin_ws
+#### START CUSTOM CATKIN_WS ####
+# RUN /bin/bash -c "mkdir -p catkin_ws/src/"
+
+# Copy or init your packages in here
+# COPY dt_dependent_node catkin_ws/src/dt_dependent_node
+# RUN chmod +x catkin_ws/src/dt_dependent_node/src/dt_dependent_node.py
+
+# Do not change the below line! This ensures that your workspace is overlayed on top of the Duckietown stack!  
+# MAKE sure this line is present in the build: This workspace overlays: /home/software/catkin_ws/devel;/opt/ros/kinetic
+# RUN /bin/bash -c "source /home/software/catkin_ws/devel/setup.bash && catkin_init_workspace && cd ../.."
+# RUN /bin/bash -c "source /home/software/catkin_ws/devel/setup.bash && catkin_make -j -C catkin_ws/"
+# RUN /bin/bash -c "source catkin_ws/devel/setup.bash"
+
+#### END CUSTOM CATKIN_WS ####
 
 # DO NOT MODIFY: your submission won't run if you do
 ENV DUCKIETOWN_SERVER=evaluator

--- a/catkin_ws/src/CMakeLists.txt
+++ b/catkin_ws/src/CMakeLists.txt
@@ -1,1 +1,0 @@
-/opt/ros/kinetic/share/catkin/cmake/toplevel.cmake

--- a/catkin_ws/src/duckietown_msgs/msg/Twist2DStamped.msg
+++ b/catkin_ws/src/duckietown_msgs/msg/Twist2DStamped.msg
@@ -1,3 +1,0 @@
-Header header
-float32 v
-float32 omega

--- a/catkin_ws/src/duckietown_msgs/msg/WheelsCmdStamped.msg
+++ b/catkin_ws/src/duckietown_msgs/msg/WheelsCmdStamped.msg
@@ -1,3 +1,0 @@
-Header header
-float32 vel_left
-float32 vel_right

--- a/dt_dependent_node/CMakeLists.txt
+++ b/dt_dependent_node/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8.3)
-project(duckietown_msgs)
+project(dt_dependent_node)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
 # add_compile_options(-std=c++11)
@@ -7,7 +7,12 @@ project(duckietown_msgs)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS roscpp rospy std_msgs sensor_msgs message_generation)
+find_package(catkin REQUIRED COMPONENTS
+  duckietown_msgs
+  roscpp
+  rospy
+  std_msgs
+)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
@@ -43,11 +48,11 @@ find_package(catkin REQUIRED COMPONENTS roscpp rospy std_msgs sensor_msgs messag
 ##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
 
 ## Generate messages in the 'msg' folder
-add_message_files(
-  FILES
-  Twist2DStamped.msg
-  WheelsCmdStamped.msg
-)
+# add_message_files(
+#   FILES
+#   Message1.msg
+#   Message2.msg
+# )
 
 ## Generate services in the 'srv' folder
 # add_service_files(
@@ -64,11 +69,10 @@ add_message_files(
 # )
 
 ## Generate added messages and services with any dependencies listed here
-generate_messages(
-  DEPENDENCIES
-  sensor_msgs
-  std_msgs  # Or other packages containing msgs
-)
+# generate_messages(
+#   DEPENDENCIES
+#   duckietown_msgs#   std_msgs
+# )
 
 ################################################
 ## Declare ROS dynamic reconfigure parameters ##
@@ -101,8 +105,8 @@ generate_messages(
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
 #  INCLUDE_DIRS include
-#  LIBRARIES duckietown_msgs
-#  CATKIN_DEPENDS other_catkin_pkg
+#  LIBRARIES dt_dependent_node
+#  CATKIN_DEPENDS duckietown_msgs roscpp rospy std_msgs
 #  DEPENDS system_lib
 )
 
@@ -114,12 +118,12 @@ catkin_package(
 ## Your package locations should be listed before other locations
 include_directories(
 # include
-# ${catkin_INCLUDE_DIRS}
+  ${catkin_INCLUDE_DIRS}
 )
 
 ## Declare a C++ library
 # add_library(${PROJECT_NAME}
-#   src/${PROJECT_NAME}/duckietown_msgs.cpp
+#   src/${PROJECT_NAME}/dt_dependent_node.cpp
 # )
 
 ## Add cmake target dependencies of the library
@@ -130,7 +134,7 @@ include_directories(
 ## Declare a C++ executable
 ## With catkin_make all packages are built within a single CMake context
 ## The recommended prefix ensures that target names across packages don't collide
-# add_executable(${PROJECT_NAME}_node src/duckietown_msgs_node.cpp)
+# add_executable(${PROJECT_NAME}_node src/dt_dependent_node_node.cpp)
 
 ## Rename C++ executable without prefix
 ## The above recommended prefix causes long target names, the following renames the
@@ -187,7 +191,7 @@ include_directories(
 #############
 
 ## Add gtest based cpp test target and link libraries
-# catkin_add_gtest(${PROJECT_NAME}-test test/test_duckietown_msgs.cpp)
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_dt_dependent_node.cpp)
 # if(TARGET ${PROJECT_NAME}-test)
 #   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
 # endif()

--- a/dt_dependent_node/package.xml
+++ b/dt_dependent_node/package.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <package format="2">
-  <name>duckietown_msgs</name>
+  <name>dt_dependent_node</name>
   <version>0.0.0</version>
-  <description>The duckietown_msgs package</description>
+  <description>The dt_dependent_node package</description>
 
   <!-- One maintainer tag required, multiple allowed, one person per tag -->
   <!-- Example:  -->
@@ -19,7 +19,7 @@
   <!-- Url tags are optional, but multiple are allowed, one per tag -->
   <!-- Optional attribute type can be: website, bugtracker, or repository -->
   <!-- Example: -->
-  <!-- <url type="website">http://wiki.ros.org/duckietown_msgs</url> -->
+  <!-- <url type="website">http://wiki.ros.org/dt_dependent_node</url> -->
 
 
   <!-- Author tags are optional, multiple are allowed, one per tag -->
@@ -37,18 +37,30 @@
   <!--   <build_depend>roscpp</build_depend> -->
   <!--   <exec_depend>roscpp</exec_depend> -->
   <!-- Use build_depend for packages you need at compile time: -->
-    <build_depend>message_generation</build_depend>
+  <!--   <build_depend>message_generation</build_depend> -->
   <!-- Use build_export_depend for packages you need in order to build against this package: -->
   <!--   <build_export_depend>message_generation</build_export_depend> -->
   <!-- Use buildtool_depend for build tool packages: -->
   <!--   <buildtool_depend>catkin</buildtool_depend> -->
   <!-- Use exec_depend for packages you need at runtime: -->
-    <exec_depend>message_runtime</exec_depend>
+  <!--   <exec_depend>message_runtime</exec_depend> -->
   <!-- Use test_depend for packages you need only for testing: -->
   <!--   <test_depend>gtest</test_depend> -->
   <!-- Use doc_depend for packages you need only for building documentation: -->
   <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>duckietown_msgs</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>rospy</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_export_depend>duckietown_msgs</build_export_depend>
+  <build_export_depend>roscpp</build_export_depend>
+  <build_export_depend>rospy</build_export_depend>
+  <build_export_depend>std_msgs</build_export_depend>
+  <exec_depend>duckietown_msgs</exec_depend>
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/dt_dependent_node/src/dt_dependent_node.py
+++ b/dt_dependent_node/src/dt_dependent_node.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+import rospy
+import numpy as np
+
+from duckietown_msgs.msg import WheelsCmdStamped
+
+def continuous_publisher():
+    vel_pub = rospy.Publisher('/random/topic/', WheelsCmdStamped, queue_size=1)
+    rospy.init_node('continuous_test_publisher', anonymous=True)
+    rate = rospy.Rate(10)
+    
+    while not rospy.is_shutdown():
+        msg = WheelsCmdStamped()
+        msg.vel_left = np.random.random()
+        msg.vel_right = np.random.random()
+
+        vel_pub.publish(msg)
+        rate.sleep()
+
+
+if __name__ == '__main__':
+    continuous_publisher()
+
+

--- a/lf_slim.launch
+++ b/lf_slim.launch
@@ -16,6 +16,7 @@
 
     <arg name="inverse_kinematics" default="true"/>
 
+    <!-- Start Lane Control -->
     <group if="$(arg lane_following)">
 
         <!-- Line Detector -->
@@ -76,4 +77,9 @@
 
     </group>
     <!-- End Lane Control -->
+
+    <!-- Start Test Node -->
+    <!-- <node pkg="dt_dependent_node" name="dt_dependent_node" type="dt_dependent_node.py" output="screen"> 
+    </node> -->
+    <!-- End Test Node -->
 </launch>


### PR DESCRIPTION
Adds the ability to add overlayed workspace, which will allow us to use nodes from the duckietown Software catkin_ws, without needing to rebuild the whole thing.

Gives simple example node (dt_dependent_node) which builds off the dependency of `duckietown_msgs` (found inside of the main catkin_ws).